### PR TITLE
chore: changing worflow runner that was creating executeables to only run on pushed tags. 

### DIFF
--- a/.github/workflows/build-exe.yml
+++ b/.github/workflows/build-exe.yml
@@ -2,8 +2,8 @@ name: Build Executeable
 
 on: 
     push: 
-        branches: 
-            - develop
+        tags: 
+            - 'v*.*.*'
     workflow_dispatch: 
 
 jobs:
@@ -129,3 +129,35 @@ jobs:
               with:
                 name: browsermon_linux_x64
                 path: artifact/
+    create_release: 
+      runs-on: ubuntu-latest
+      needs: [build_win_x86, build_win_x64, build_linux_x86]
+      steps:
+        - name: Download Artifacts
+          uses: actions/download-artifact@v2
+          with:
+            name: browsermon_win_x86
+            path: browsermon_win_x86
+
+        - name: Download Artifacts
+          uses: actions/download-artifact@v2
+          with:
+            name: browsermon_win_x64
+            path: browsermon_win_x64
+
+        - name: Download Artifacts
+          uses: actions/download-artifact@v2
+          with:
+            name: browsermon_linux_x64
+            path: browsermon_linux_x64
+        
+        - name: Create Github Release
+          uses: softprops/action-gh-release@v1
+          with:
+            files: |
+              browsermon_win_x86
+              browsermon_win_x64
+              browsermon_linux_x64
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}    
+            

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,7 +91,7 @@ jobs:
                 name: browsermon_win_x64
                 path: artifact/
     
-    build_linux_x86:
+    build_linux_x64:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
@@ -131,7 +131,7 @@ jobs:
                 path: artifact/
     create_release: 
       runs-on: ubuntu-latest
-      needs: [build_win_x86, build_win_x64, build_linux_x86]
+      needs: [build_win_x86, build_win_x64, build_linux_x64]
       steps:
         - name: Download Artifacts
           uses: actions/download-artifact@v2
@@ -151,12 +151,22 @@ jobs:
             name: browsermon_linux_x64
             path: browsermon_linux_x64
         
+        - name: Zip Artifacts
+          run: |
+            cd browsermon_win_x86
+            zip -r ../browsermon_win_x86.zip .
+            cd ../browsermon_win_x64
+            zip -r ../browsermon_win_x64.zip .
+            cd ../browsermon_linux_x64
+            zip -r ../browsermon_linux_x64.zip .
+            cd ..
+        
         - name: Create Github Release
           uses: softprops/action-gh-release@v1
           with:
             files: |
-              browsermon_win_x86
-              browsermon_win_x64
-              browsermon_linux_x64
+              browsermon_win_x86.zip
+              browsermon_win_x64.zip
+              browsermon_linux_x64.zip
           env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}    
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Build Executeable 
+name: release 
 
 on: 
     push: 
@@ -160,4 +160,3 @@ jobs:
               browsermon_linux_x64
           env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}    
-            


### PR DESCRIPTION
#5 
Previously: build-exe runner was running on every push. 
Changed: Now the runner will only run when there is a tag push which will most  likely happen when a version is final and has been tested than only executeables will be made and release will be made. 